### PR TITLE
Add ability to auth with an API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ dependencies {
 
 #Usage
 
+Classes can be loaded using either an API Key, or your username and password.
+
 ##Suppressions
 ```java
-SuppressionManager suppressionMgr = new SuppressionManager("username","password");
+SuppressionManager suppressionMgr = new SuppressionManager("apiKey"); // or:
+//SuppressionManager suppressionMgr = new SuppressionManager("username", "password");
 
 //get Suppression for a particular group and user
 Suppression suppression = suppressionMgr.retrieve(42, "email");
@@ -88,7 +91,8 @@ List<String> emails = suppressionMgr.retrieve(group);
 
 ##Groups
 ```java
-GroupManager groupMgr = new GroupManager("username", "password");
+GroupManager groupMgr = new GroupManager("apiKey"); // or:
+//GroupManager groupMgr = new GroupManager("username", "password");
 
 //retrieve all groups
 List<Group> groups = groupMgr.retrieve();
@@ -106,8 +110,8 @@ groupMgr.remove(group);
 
 ##Global Suppressions
 ```java
-GlobalSuppressionManager globalMgr =
-	new GlobalSuppressionManager("username", "password");
+GlobalSuppressionManager globalMgr = new GlobalSuppressionManager("apiKey"); // or:
+//GlobalSuppressionManager globalMgr = new GlobalSuppressionManager("username", "password");
 
 if (globalMgr.has("email")){
 	//do something
@@ -121,4 +125,11 @@ globalMgr.add("email", "email2", "email3");
 globalMgr.remove("email", "email2", "email3");
 
 
+```
+
+# Tests
+Integration tests run against an actual SendGrid account with either form of credentials:
+```
+mvn -Dsendgrid-username=ABC -Dsendgrid-password=XXXXX clean test
+mvn -Dsendgrid-apikey=XXXXX clean test
 ```

--- a/src/main/java/com/github/krenfro/sendgrid/asm/GlobalSuppressionManager.java
+++ b/src/main/java/com/github/krenfro/sendgrid/asm/GlobalSuppressionManager.java
@@ -9,16 +9,20 @@ import org.apache.http.entity.ContentType;
 
 /**
  * Global Suppressions are email addresses that will not receive any emails.
- * 
+ *
  * https://sendgrid.com/docs/API_Reference/Web_API_v3/Advanced_Suppression_Manager/global_suppressions.html
  */
 public class GlobalSuppressionManager extends SendGrid{
-    
+
     public GlobalSuppressionManager(String username, String password){
         super(username, password);
     }
-        
-    public List<String> add(String ... email) throws IOException{        
+
+    public GlobalSuppressionManager(String apiKey){
+        super(apiKey);
+    }
+
+    public List<String> add(String ... email) throws IOException{
         List<String> suppressions = new ArrayList<>();
         Map<String,Object> map = new HashMap<>();
         map.put("recipient_emails", email);
@@ -29,7 +33,7 @@ public class GlobalSuppressionManager extends SendGrid{
         try{
             String json = post
                     .bodyString(payload, ContentType.APPLICATION_JSON)
-                    .execute().returnContent().asString();            
+                    .execute().returnContent().asString();
             JsonNode array = jackson.readTree(json).path("recipient_emails");
             if (array.isArray()){
                 for (final JsonNode entry : array) {
@@ -42,8 +46,8 @@ public class GlobalSuppressionManager extends SendGrid{
         }
         return suppressions;
     }
-    
-    public boolean has(String email) throws IOException{                
+
+    public boolean has(String email) throws IOException{
         Request get = Request.Get(baseUrl + "/suppressions/global/" + email)
                 .addHeader("Accept", "application/json")
                 .addHeader("Authorization", authHeader);
@@ -55,19 +59,19 @@ public class GlobalSuppressionManager extends SendGrid{
             throw new IOException(ex);
         }
     }
-                
-    public void remove(String ... email) throws IOException{         
-        
+
+    public void remove(String ... email) throws IOException{
+
         for (String entry: email){
             Request delete = Request.Delete(baseUrl + "/suppressions/global/" + entry)
                     .addHeader("Accept", "application/json")
-                    .addHeader("Authorization", authHeader);    
+                    .addHeader("Authorization", authHeader);
             try{
                 delete.execute();
             }
             catch(HttpResponseException ex){
                 throw new IOException(ex);
-            }  
+            }
         }
-    }    
+    }
 }

--- a/src/main/java/com/github/krenfro/sendgrid/asm/Group.java
+++ b/src/main/java/com/github/krenfro/sendgrid/asm/Group.java
@@ -3,7 +3,7 @@ package com.github.krenfro.sendgrid.asm;
 import java.util.Objects;
 
 public class Group {
-    
+
     private Integer id;
     private String name;
     private String description;
@@ -40,8 +40,8 @@ public class Group {
 
     public void setLastEmailSentAt(String lastEmailSentAt) {
         this.lastEmailSentAt = lastEmailSentAt;
-    }    
-    
+    }
+
     public Integer getUnsubscribes() {
         return unsubscribes;
     }
@@ -83,5 +83,5 @@ public class Group {
             return false;
         }
         return true;
-    }    
+    }
 }

--- a/src/main/java/com/github/krenfro/sendgrid/asm/GroupManager.java
+++ b/src/main/java/com/github/krenfro/sendgrid/asm/GroupManager.java
@@ -9,22 +9,27 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
 /**
- * Groups are individual types of email you would like your users to be able to 
+ * Groups are individual types of email you would like your users to be able to
  * unsubscribe from, (e.g. Newsletters, Invoices, Alerts).
- * 
+ *
  * https://sendgrid.com/docs/API_Reference/Web_API_v3/Advanced_Suppression_Manager/groups.html
  */
 public class GroupManager extends SendGrid{
-    
+
     public GroupManager(String username, String password){
         super(username, password);
+        baseUrl = baseUrl.concat("/groups");
+    }
+
+    public GroupManager(String apiKey){
+        super(apiKey);
         baseUrl = baseUrl.concat("/groups");
     }
 
     public Group retrieve(int id) throws IOException{
         Request get = Request.Get(baseUrl.concat("/" + id))
                 .addHeader("Accept", "application/json")
-                .addHeader("Authorization", authHeader);       
+                .addHeader("Authorization", authHeader);
         try{
             String json = get.execute().returnContent().asString();
             return jackson.readValue(json, Group.class);
@@ -33,8 +38,8 @@ public class GroupManager extends SendGrid{
             throw new IOException(ex);
         }
     }
-    
-    public Group add(String name, String description) throws IOException{        
+
+    public Group add(String name, String description) throws IOException{
         Map<String,String> map = new HashMap<>();
         map.put("name", name);
         map.put("description", description);
@@ -46,20 +51,20 @@ public class GroupManager extends SendGrid{
             String json = post
                     .bodyString(payload, ContentType.APPLICATION_JSON)
                     .execute().returnContent().asString();
-            return jackson.readValue(json, Group.class); 
+            return jackson.readValue(json, Group.class);
         }
         catch(HttpResponseException ex){
             throw new IOException(ex);
         }
     }
-    
-    public Group update(Group group) throws IOException{        
+
+    public Group update(Group group) throws IOException{
         Objects.requireNonNull(group);
         if (group.getId() == null){
             throw new IllegalArgumentException(
                     "Group has no id. Perhaps invoke create() instead of update()");
-        }        
-        
+        }
+
         throw new UnsupportedOperationException(
                 "Update is not yet supported.  Need Apache HttpClient > 4.4+");
         /*
@@ -74,27 +79,27 @@ public class GroupManager extends SendGrid{
             String json = patch
                 .bodyString(payload, ContentType.APPLICATION_JSON)
                 .execute().returnContent().asString();
-            return jackson.readValue(json, Group.class);         
+            return jackson.readValue(json, Group.class);
         }
         catch(HttpResponseException ex){
             throw new IOException(ex);
         }
         */
-    }   
-    
+    }
+
     public boolean remove(Group group) throws IOException{
         Objects.requireNonNull(group);
         Request delete = Request.Delete(baseUrl.concat("/" + group.getId()))
-                .addHeader("Authorization", authHeader);    
+                .addHeader("Authorization", authHeader);
         try{
             HttpResponse response = delete.execute().returnResponse();
             return response.getStatusLine().getStatusCode() == 204;
         }
         catch(HttpResponseException ex){
             throw new IOException(ex);
-        }        
-    }    
-    
+        }
+    }
+
     public List<Group> retrieve() throws IOException{
         Request get = Request.Get(baseUrl)
                 .addHeader("Accept", "application/json")
@@ -102,12 +107,12 @@ public class GroupManager extends SendGrid{
         try{
             String json = get.execute().returnContent().asString();
             TypeReference<List<Group>> typeRef = new TypeReference<List<Group>>() {};
-            return jackson.readValue(json, typeRef);       
+            return jackson.readValue(json, typeRef);
         }
         catch(HttpResponseException ex){
             throw new IOException(ex);
         }
     }
-    
-     
+
+
 }

--- a/src/main/java/com/github/krenfro/sendgrid/asm/SendGrid.java
+++ b/src/main/java/com/github/krenfro/sendgrid/asm/SendGrid.java
@@ -6,16 +6,25 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import java.io.IOException;
 import org.apache.commons.codec.binary.Base64;
 
-public abstract class SendGrid {    
-    
+public abstract class SendGrid {
+
     public static final String DEFAULT_URL = "https://api.sendgrid.com/v3/asm";
-    protected String baseUrl = DEFAULT_URL;    
+    protected String baseUrl = DEFAULT_URL;
     protected final String authHeader;
     protected ObjectMapper jackson;
-    
+
     public SendGrid(String username, String password){
         authHeader = "Basic " + Base64.encodeBase64String(
                 String.format("%s:%s", username, password).getBytes());
+        setupJackson();
+    }
+
+    public SendGrid(String apiKey) {
+        authHeader = "Bearer " + Base64.encodeBase64String(apiKey.getBytes());
+        setupJackson();
+    }
+
+    private void setupJackson() {
         jackson = new ObjectMapper();
         jackson.setPropertyNamingStrategy(
                 PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);

--- a/src/main/java/com/github/krenfro/sendgrid/asm/Suppression.java
+++ b/src/main/java/com/github/krenfro/sendgrid/asm/Suppression.java
@@ -3,12 +3,12 @@ package com.github.krenfro.sendgrid.asm;
 import java.util.Objects;
 
 public class Suppression {
-    
+
     private Integer id;
     private String name;
     private String description;
     private boolean suppressed;
-    
+
     public Integer getId() {
         return id;
     }
@@ -44,8 +44,8 @@ public class Suppression {
     @Override
     public String toString(){
         return "Suppression{" + "id=" + id + ", name=" + name + ", description=" + description + ", suppressed=" + suppressed + '}';
-    }    
-    
+    }
+
     @Override
     public int hashCode(){
         int hash = 5;
@@ -74,5 +74,5 @@ public class Suppression {
             return false;
         }
         return true;
-    }    
+    }
 }

--- a/src/test/java/com/github/krenfro/sendgrid/asm/AbstractTest.java
+++ b/src/test/java/com/github/krenfro/sendgrid/asm/AbstractTest.java
@@ -1,0 +1,42 @@
+package com.github.krenfro.sendgrid.asm;
+
+import java.io.IOException;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public abstract class AbstractTest {
+
+    /* When running these tests, use Java environment variables to set credentials one of two ways:
+        mvn -Dsendgrid-username=ABC -Dsendgrid-password=XXXXX clean test
+        mvn -Dsendgrid-apikey=XXXXX clean test
+    */
+    public static final String API_KEY = System.getProperty("sendgrid-apikey");
+    public static final String USERNAME = System.getProperty("sendgrid-username");
+    public static final String PASSWORD = System.getProperty("sendgrid-password");
+
+    public static GroupManager getGroupManager() {
+        if(API_KEY != null && !API_KEY.isEmpty()) {
+            return new GroupManager(API_KEY);
+        } else {
+            return new GroupManager(USERNAME, PASSWORD);
+        }
+    }
+
+    public static GlobalSuppressionManager getGlobalSuppressionManager() {
+        if(API_KEY != null && !API_KEY.isEmpty()) {
+            return new GlobalSuppressionManager(API_KEY);
+        } else {
+            return new GlobalSuppressionManager(USERNAME, PASSWORD);
+        }
+    }
+
+    public static SuppressionManager getSuppressionManager() {
+        if(API_KEY != null && !API_KEY.isEmpty()) {
+            return new SuppressionManager(API_KEY);
+        } else {
+            return new SuppressionManager(USERNAME, PASSWORD);
+        }
+    }
+}

--- a/src/test/java/com/github/krenfro/sendgrid/asm/GlobalSuppressionManagerTest.java
+++ b/src/test/java/com/github/krenfro/sendgrid/asm/GlobalSuppressionManagerTest.java
@@ -6,25 +6,20 @@ import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class GlobalSuppressionManagerTest {
-    
-    /* When running these tests, use Java environment variables to set credentials:
-       e.g., "mvn -Dsendgrid-username=ABC -Dsendgrid-password=XXXXX clean test"    
-    */    
-    public static final String USERNAME = System.getProperty("sendgrid-username");
-    public static final String PASSWORD = System.getProperty("sendgrid-password");       
-    public static final String TEST_EMAIL = "junit@does-not-exist.com"; 
-    
+public class GlobalSuppressionManagerTest extends AbstractTest {
+
+    public static final String TEST_EMAIL = "junit@does-not-exist.com";
+
     @BeforeClass
     @AfterClass
-    public static void cleanup() throws IOException{        
-        GlobalSuppressionManager gsm = new GlobalSuppressionManager(USERNAME, PASSWORD);
+    public static void cleanup() throws IOException{
+        GlobalSuppressionManager gsm = getGlobalSuppressionManager();
         gsm.remove(TEST_EMAIL);
     }
-    
+
     @Test
-    public void testOperations() throws IOException{        
-        GlobalSuppressionManager gsm = new GlobalSuppressionManager(USERNAME, PASSWORD);
+    public void testOperations() throws IOException{
+        GlobalSuppressionManager gsm = getGlobalSuppressionManager();
         assertFalse(gsm.has(TEST_EMAIL));
         assertTrue(gsm.add(TEST_EMAIL).contains(TEST_EMAIL));
         assertTrue(gsm.has(TEST_EMAIL));

--- a/src/test/java/com/github/krenfro/sendgrid/asm/GroupManagerTest.java
+++ b/src/test/java/com/github/krenfro/sendgrid/asm/GroupManagerTest.java
@@ -6,19 +6,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-public class GroupManagerTest {
+public class GroupManagerTest extends AbstractTest {
 
-    /* When running these tests, use Java environment variables to set credentials:
-       e.g., "mvn -Dsendgrid-username=ABC -Dsendgrid-password=XXXXX clean test"    
-    */    
-    public static final String USERNAME = System.getProperty("sendgrid-username");
-    public static final String PASSWORD = System.getProperty("sendgrid-password");    
-    public static final String TEST_GROUP_NAME = "junit-group";        
-    
+    public static final String TEST_GROUP_NAME = "junit-group";
+
     @BeforeClass
     @AfterClass
-    public static void cleanup() throws IOException{        
-        GroupManager groups = new GroupManager(USERNAME, PASSWORD);
+    public static void cleanup() throws IOException{
+        GroupManager groups = getGroupManager();
         for (Group group: groups.retrieve()){
             if (group.getName().equals(TEST_GROUP_NAME)){
                 groups.remove(group);
@@ -26,10 +21,10 @@ public class GroupManagerTest {
             }
         }
     }
-    
+
     @Test
     public void testOperations() throws IOException{
-        GroupManager groups = new GroupManager(USERNAME, PASSWORD);
+        GroupManager groups = getGroupManager();
         Group group = groups.add(TEST_GROUP_NAME, "test group");
         assertNotNull(group.getId());
         assertEquals(TEST_GROUP_NAME, group.getName());

--- a/src/test/java/com/github/krenfro/sendgrid/asm/SuppressionManagerTest.java
+++ b/src/test/java/com/github/krenfro/sendgrid/asm/SuppressionManagerTest.java
@@ -7,22 +7,17 @@ import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class SuppressionManagerTest {
-    
-    /* When running these tests, use Java environment variables to set credentials:
-       e.g., "mvn -Dsendgrid-username=ABC -Dsendgrid-password=XXXXX clean test"    
-    */    
-    public static final String USERNAME = System.getProperty("sendgrid-username");
-    public static final String PASSWORD = System.getProperty("sendgrid-password");    
-    public static final String TEST_GROUP_NAME = "junit-suppression-group";          
+public class SuppressionManagerTest extends AbstractTest  {
+
+    public static final String TEST_GROUP_NAME = "junit-suppression-group";
     public static final String TEST_EMAIL = "junit@does-not-exist.com";
-    
+
     @BeforeClass
     @AfterClass
-    public static void cleanup() throws IOException{        
-        GroupManager groups = new GroupManager(USERNAME, PASSWORD);
-        SuppressionManager suppressionManager = new SuppressionManager(USERNAME, PASSWORD);        
-        List<Suppression> suppressions = suppressionManager.retrieve(TEST_EMAIL);        
+    public static void cleanup() throws IOException{
+        GroupManager groups = getGroupManager();
+        SuppressionManager suppressionManager = getSuppressionManager();
+        List<Suppression> suppressions = suppressionManager.retrieve(TEST_EMAIL);
         for (Suppression suppression: suppressions){
             suppression.setSuppressed(false);
         }
@@ -34,12 +29,12 @@ public class SuppressionManagerTest {
             }
         }
     }
-    
+
     @Test
     public void testOperations() throws IOException{
-        GroupManager groupManager = new GroupManager(USERNAME, PASSWORD);
+        GroupManager groupManager = getGroupManager();
         Group group = groupManager.add(TEST_GROUP_NAME, "test group");
-        SuppressionManager suppressionManager = new SuppressionManager(USERNAME, PASSWORD);
+        SuppressionManager suppressionManager = getSuppressionManager();
         List<Suppression> list = suppressionManager.retrieve(TEST_EMAIL);
         assertFalse(list.isEmpty());
         for (Suppression suppression: list){
@@ -47,13 +42,13 @@ public class SuppressionManagerTest {
         }
         assertTrue(suppressionManager.retrieve(group).isEmpty());
         suppressionManager.remove(group, TEST_EMAIL);
-        
+
         //add a suppression
         List<String> addresses = suppressionManager.add(group, TEST_EMAIL);
         assertFalse(addresses.isEmpty());
         assertTrue(addresses.contains(TEST_EMAIL));
         assertTrue(suppressionManager.retrieve(group).contains(TEST_EMAIL));
-        
+
         //ensure suppression is there
         List<Suppression> suppressions = suppressionManager.retrieve(TEST_EMAIL);
         for (Suppression s: suppressions){
@@ -65,7 +60,7 @@ public class SuppressionManagerTest {
                 assertFalse(s.isSuppressed());
             }
         }
-        
+
         //all suppressions should be false
         suppressionManager.save(TEST_EMAIL, suppressions);
         List<Suppression> updated = suppressionManager.retrieve(TEST_EMAIL);
@@ -76,7 +71,7 @@ public class SuppressionManagerTest {
                 }
             }
         }
-        
+
         suppressionManager.remove(group, TEST_EMAIL);
         assertFalse(suppressionManager.retrieve(group).contains(TEST_EMAIL));
         groupManager.remove(group);


### PR DESCRIPTION
SendGrid has added the ability to authenticate with API Keys. This is now their preferred way to authenticate because it allows you to fine-grain permissions on a per-key basis. The old username/password method still works as expected.

I've updated the documentation to prefer the API Key method and added instructions for running the tests.

Sorry for all the whitespace changes. My editor trims extra whitespace.